### PR TITLE
websocket provider did not listen to deposit event on test chains

### DIFF
--- a/scripts/subscribeEthereumDeposit.js
+++ b/scripts/subscribeEthereumDeposit.js
@@ -90,7 +90,7 @@ async function main (networkName, pegContractAddress) {
             process.env.AlCHEMY_API_KEY
         );
     } else {
-        provider = ethers.providers.InfuraProvider.getWebSocketProvider(process.env.ETH_NETWORK, process.env.INFURA_API_KEY);
+        provider = ethers.providers.InfuraProvider(process.env.ETH_NETWORK, process.env.INFURA_API_KEY);
     }
 
     const keyring = new Keyring({type: 'sr25519'});


### PR DESCRIPTION
Claim relayer on Nikau/Rata did not listen to ethereum deposits and so no entries went in db..
We wanted to use WebSocket for main net when Infura wasn't working...switching back to Infura for testnet..
if we can deploy this image, it will unblock Felix from testing