### PR TITLE
Fix node version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:16.5.0-alpine
 ENV PYCURL_SSL_LIBRARY=openssl
 RUN apk add --no-cache --virtual .build-deps build-base python3-dev py3-pip git \
     # keep libcurl in the image

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "bugs": {
     "url": "https://github.com/cennznet/cennznet/issues"
   },
+  "engines": { "node": ">=0.12 < 17.5.0" },
   "homepage": "https://github.com/cennznet/cennznet#readme",
   "dependencies": {
     "@types/chai": "^4.2.19",

--- a/scripts/subscribeEthereumDeposit.js
+++ b/scripts/subscribeEthereumDeposit.js
@@ -76,34 +76,6 @@ async function sendClaim(claim, transactionHash, api, signer, nonce) {
     });
 }
 
-// Fetch from db all transaction with EthereumConfirming status and send claims for them
-async function claimEthereumPendingTx(api, provider, claimer, eventConfirmation) {
-    const recordWithEthConfirm = await BridgeClaim.find({status: 'EthereumConfirming'});
-    console.log('recordWithEthConfirm status:',recordWithEthConfirm);
-    let nonce = (await api.rpc.system.accountNextIndex(claimer.address)).toNumber();
-    await Promise.all(
-        recordWithEthConfirm.map(async (bridgeClaimRecord) => {
-            const transactionHash = bridgeClaimRecord.txHash;
-            const txReceipt = await provider.getTransaction(transactionHash); // The receipt is not available for pending transactions and returns null.
-            console.log('txReceipt::',txReceipt);
-            // if receipt for tx hash exist and satisfies confirmation criteris, send claim to CENNZnet chain
-            if (txReceipt && txReceipt.blockNumber && txReceipt.confirmations >= eventConfirmation ) {
-               // decode the input data
-                const [tokenAddress, amount, cennznetAddress] = ethers.utils.defaultAbiCoder.decode(
-                    ['address', 'uint256', 'bytes32'],
-                    ethers.utils.hexDataSlice(txReceipt.data, 4)
-                );
-                const claim = {
-                    tokenAddress,
-                    amount: amount.toString(),
-                    beneficiary: cennznetAddress
-                };
-                await sendClaim(claim, transactionHash, api, claimer, nonce++);
-            }
-        })
-    );
-}
-
 async function main (networkName, pegContractAddress) {
     networkName = networkName || 'local';
     const connectionStr = process.env.MONGO_URI;
@@ -133,8 +105,6 @@ async function main (networkName, pegContractAddress) {
     logger.info(`CENNZnet peg deployed to: ${peg.address}`);
     const eventConfirmation = (await api.query.ethBridge.eventConfirmations()).toNumber();
     logger.info(`eventConfirmation::${eventConfirmation}`);
-
-    await claimEthereumPendingTx(api, provider, claimer, eventConfirmation);
 
     peg.on("Deposit", async (sender, tokenAddress, amount, cennznetAddress, eventInfo) => {
         logger.info(`Got the event...${JSON.stringify(eventInfo)}`);


### PR DESCRIPTION


Claim relayer (rata) is throwing this error
```
QueryCursor.prototype.map = function(fn) {                                                                                                                     │
│                           ^                                                                                                                                    │
│ TypeError: Cannot assign to read only property 'map' of object '#<QueryCursor>'                                                                                │
│     at Object.<anonymous> (/node_modules/mongoose/lib/cursor/QueryCursor.js:144:27)                                                                            │
```
More details
https://stackoverflow.com/questions/71185161/i-am-getting-this-error-typeerror-cannot-assign-to-read-only-property-map-of