### PR TITLE
Wrapped CENNZ contract 

### DIFF
--- a/contracts/MockBridge.sol
+++ b/contracts/MockBridge.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+// Proof of a witnessed event by CENNZnet validators
+struct CENNZnetEventProof {
+    // The Id (nonce) of the event
+    uint256 eventId;
+    // The validator set Id which witnessed the event
+    uint32 validatorSetId;
+    // v,r,s are sparse arrays expected to align w public key in 'validators'
+    // i.e. v[i], r[i], s[i] matches the i-th validator[i]
+    // v part of validator signatures
+    uint8[] v;
+    // r part of validator signatures
+    bytes32[] r;
+    // s part of validator signatures
+    bytes32[] s;
+    // The validator addresses
+    address[] validators;
+}
+
+contract MockBridge is Ownable {
+    // Mock VerifyMessage for use with WCENNZ tests
+    function verifyMessage(bytes calldata message, CENNZnetEventProof calldata proof) payable external {}
+
+}

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract WrappedCENNZ is ERC20 {
-    // CENNZ ERC20 contract address
+    // CENNZnet erc20 peg address
     address public pegAddress;
 
     constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -6,8 +6,6 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract WrappedCENNZ is ERC20 {
     // CENNZ ERC20 contract address
     address public pegAddress;
-    mapping(address => mapping(address => uint256)) private _allowances;
-
 
     constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {
         pegAddress = _pegAddress;
@@ -16,18 +14,16 @@ contract WrappedCENNZ is ERC20 {
     function transferFrom(address owner, address buyer, uint256 numTokens) public override returns (bool) {
         if (msg.sender == pegAddress) {
             _burn(owner, numTokens);
-        } else {
-            super.transferFrom(owner, buyer, numTokens);
+            return true;
         }
-        return true;
+        return super.transferFrom(owner, buyer, numTokens);
     }
 
     function transfer(address buyer, uint256 numTokens) public override returns (bool) {
         if (msg.sender == pegAddress) {
             _mint(buyer, numTokens);
-        } else {
-            _transfer(msg.sender, buyer, numTokens);
+            return true;
         }
-        return true;
+        return super.transfer(buyer, numTokens);
     }
 }

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -17,13 +17,7 @@ contract WrappedCENNZ is ERC20 {
         if (msg.sender == pegAddress) {
             _burn(owner, numTokens);
         } else {
-            _transfer(owner, buyer, numTokens);
-
-            uint256 currentAllowance = _allowances[owner][_msgSender()];
-            require(currentAllowance >= numTokens, "ERC20: transfer amount exceeds allowance");
-            unchecked {
-                _approve(owner, _msgSender(), currentAllowance - numTokens);
-            }
+            super.transferFrom(owner, buyer, numTokens);
         }
         return true;
     }

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -6,25 +6,34 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 contract WrappedCENNZ is ERC20 {
     // CENNZ ERC20 contract address
     address public pegAddress;
+    mapping(address => mapping(address => uint256)) private _allowances;
+
 
     constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {
         pegAddress = _pegAddress;
     }
 
     function transferFrom(address owner, address buyer, uint256 numTokens) public override returns (bool) {
-        require(msg.sender == pegAddress);
-        require(owner != buyer);
-        require(buyer == pegAddress);
+        if (msg.sender == pegAddress) {
+            _burn(owner, numTokens);
+        } else {
+            _transfer(owner, buyer, numTokens);
 
-        _burn(owner, numTokens);
-
+            uint256 currentAllowance = _allowances[owner][_msgSender()];
+            require(currentAllowance >= numTokens, "ERC20: transfer amount exceeds allowance");
+            unchecked {
+                _approve(owner, _msgSender(), currentAllowance - numTokens);
+            }
+        }
         return true;
     }
 
     function transfer(address buyer, uint256 numTokens) public override returns (bool) {
-        require(msg.sender == pegAddress);
-        _mint(buyer, numTokens);
-
+        if (msg.sender == pegAddress) {
+            _mint(buyer, numTokens);
+        } else {
+            _transfer(msg.sender, buyer, numTokens);
+        }
         return true;
     }
 }

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract WrappedCENNZ is ERC20 {
+    // CENNZ ERC20 contract address
+    address public pegAddress;
+
+    constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {
+        pegAddress = _pegAddress;
+    }
+
+    function transferFrom(address owner, address buyer, uint256 numTokens) public override returns (bool) {
+        require(msg.sender == pegAddress);
+        require(owner != buyer);
+        require(buyer == pegAddress);
+
+        _burn(owner, numTokens);
+
+        return true;
+    }
+
+    function transfer(address buyer, uint256 numTokens) public override returns (bool) {
+        require(msg.sender == pegAddress);
+        _mint(buyer, numTokens);
+
+        return true;
+    }
+}

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -28,27 +28,13 @@ describe('Erc20Peg', () => {
         await erc20Peg.activateWithdrawals();
         await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
 
-        // SETUP: bridge contract validators
-        let validatorPublicKey = '0x0204dad6fc9c291c68498de501c6d6d17bfe28aee69cfbf71b2cc849caafcb0159';
-        let validatorAddress = utils.computeAddress(validatorPublicKey);
-        let validatorSetId = 0;
-        await bridge.forceActiveValidatorSet(
-            // 'Alice' default CENNZnet ECDSA public key converted to Eth address
-            [validatorAddress],
-            validatorSetId,
-        );
-        let verificationFee = await bridge.verificationFee();
-        // A CENNZnet validator signature for withdraw event: (ETH_RESERVED_TOKEN_ADDRESS, 5644, 0xa86e122EdbDcBA4bF24a2Abf89F5C230b37DF49d)
-        let signature = utils.splitSignature(
-            utils.hexlify('0x67bb4327409a32ce8acd415a836ba9106d3371281cc8dc646f075c18a21717701b48bd8b57c4193a20acef0c3ab7a6fcc5f7f6b27e199b1a51b38bda857bdc1601')
-        );
-        let withdrawProof = {
+        let fakeWithdrawProof = {
             eventId: 1,
             validatorSetId: 0,
-            validators: [validatorAddress],
-            v: [signature.v],
-            r: [signature.r],
-            s: [signature.s],
+            validators: [],
+            v: [],
+            r: [],
+            s: [],
         };
 
         // TEST
@@ -56,10 +42,9 @@ describe('Erc20Peg', () => {
             wrappedCENNZ.address,
             withdrawalAmount,
             wallet.address,
-            withdrawProof,
+            fakeWithdrawProof,
             {
                 gasLimit: 500000,
-                value: verificationFee
             }
         );
 
@@ -68,10 +53,9 @@ describe('Erc20Peg', () => {
                 wrappedCENNZ.address,
                 withdrawalAmount,
                 wallet.address,
-                withdrawProof,
+                fakeWithdrawProof,
                 {
                     gasLimit: estimatedGas,
-                    value: verificationFee
                 })
         ).to.emit(erc20Peg, 'Withdraw').withArgs(wallet.address, wrappedCENNZ.address, withdrawalAmount);
 

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -193,18 +193,18 @@ describe('Erc20Peg', () => {
 
         let transferAmount = 9;
         let recipient = '0xa86e122EdbDcBA4bF24a2Abf89F5C230b37DF49d';
-        let approvedAccount = '0x430abA96F6E32B528CDCc18ad01b7f484C628819';
 
         expect(recipient).not.equals(wallet.address);
         let recipientBalanceBeforeTransfer = await wrappedCENNZ.balanceOf(recipient);
         expect(recipientBalanceBeforeTransfer).to.equal(0);
 
         await wrappedCENNZ.approve(
-            approvedAccount,
+            walletTo.address,
             transferAmount
         );
+        const approvedAccount = wrappedCENNZ.connect(walletTo);
 
-        estimatedGas = await wrappedCENNZ.estimateGas.transferFrom(
+        estimatedGas = await approvedAccount.estimateGas.transferFrom(
             wallet.address,
             recipient,
             transferAmount,
@@ -212,17 +212,12 @@ describe('Erc20Peg', () => {
                 gasLimit: 500000,
             }
         );
-        const infuraProvider = new ethers.providers.InfuraProvider(process.env.ETH_NETWORK,
-            process.env.INFURA_API_KEY
-        );
-        let approvedWallet = new ethers.Wallet(process.env.ETH_ACCOUNT_KEY, infuraProvider);
-        await wrappedCENNZ.transferFrom(
+        await approvedAccount.transferFrom(
             wallet.address,
             recipient,
             transferAmount,
             {
-                gasLimit: estimatedGas,
-                from: approvedWallet
+                gasLimit: estimatedGas
             },
         );
 

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -47,6 +47,7 @@ describe('Erc20Peg', () => {
                 gasLimit: 500000,
             }
         );
+        console.log(`withdraw gas: ${estimatedGas}`);
 
         await expect(
             erc20Peg.withdraw(

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -1,0 +1,111 @@
+import { expect, use } from 'chai';
+import { Contract, utils } from 'ethers';
+import { deployContract, MockProvider, solidity } from 'ethereum-waffle';
+import CENNZnetBridge from '../artifacts/contracts/CENNZnetBridge.sol/CENNZnetBridge.json';
+import ERC20Peg from '../artifacts/contracts/ERC20Peg.sol/ERC20Peg.json';
+import MockBridge from '../artifacts/contracts/MockBridge.sol/MockBridge.json';
+import WrappedCENNZ from '../artifacts/contracts/WrappedCENNZ.sol/WrappedCENNZ.json';
+
+use(solidity);
+
+describe('Erc20Peg', () => {
+    const [wallet, walletTo] = new MockProvider().getWallets();
+    let bridge: Contract;
+    let erc20Peg: Contract;
+    let mockBridge: Contract;
+    let wrappedCENNZ: Contract;
+
+    beforeEach(async () => {
+        bridge = await deployContract(wallet, CENNZnetBridge, []);
+        mockBridge = await deployContract(wallet, MockBridge, []);
+        erc20Peg = await deployContract(wallet, ERC20Peg, [mockBridge.address]);
+        wrappedCENNZ = await deployContract(wallet, WrappedCENNZ, [erc20Peg.address]);
+    });
+
+    it('withdraw wrapped CENNZ then deposit', async () => {
+        let withdrawalAmount = 10;
+        let userBalanceStart = await wrappedCENNZ.balanceOf(wallet.address);
+        await erc20Peg.activateWithdrawals();
+        await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
+
+        // SETUP: bridge contract validators
+        let validatorPublicKey = '0x0204dad6fc9c291c68498de501c6d6d17bfe28aee69cfbf71b2cc849caafcb0159';
+        let validatorAddress = utils.computeAddress(validatorPublicKey);
+        let validatorSetId = 0;
+        await bridge.forceActiveValidatorSet(
+            // 'Alice' default CENNZnet ECDSA public key converted to Eth address
+            [validatorAddress],
+            validatorSetId,
+        );
+        let verificationFee = await bridge.verificationFee();
+        // A CENNZnet validator signature for withdraw event: (ETH_RESERVED_TOKEN_ADDRESS, 5644, 0xa86e122EdbDcBA4bF24a2Abf89F5C230b37DF49d)
+        let signature = utils.splitSignature(
+            utils.hexlify('0x67bb4327409a32ce8acd415a836ba9106d3371281cc8dc646f075c18a21717701b48bd8b57c4193a20acef0c3ab7a6fcc5f7f6b27e199b1a51b38bda857bdc1601')
+        );
+        let withdrawProof = {
+            eventId: 1,
+            validatorSetId: 0,
+            validators: [validatorAddress],
+            v: [signature.v],
+            r: [signature.r],
+            s: [signature.s],
+        };
+
+        // TEST
+        let estimatedGas = await erc20Peg.estimateGas.withdraw(
+            wrappedCENNZ.address,
+            withdrawalAmount,
+            wallet.address,
+            withdrawProof,
+            {
+                gasLimit: 500000,
+                value: verificationFee
+            }
+        );
+
+        await expect(
+            erc20Peg.withdraw(
+                wrappedCENNZ.address,
+                withdrawalAmount,
+                wallet.address,
+                withdrawProof,
+                {
+                    gasLimit: estimatedGas,
+                    value: verificationFee
+                })
+        ).to.emit(erc20Peg, 'Withdraw').withArgs(wallet.address, wrappedCENNZ.address, withdrawalAmount);
+
+        // Check wallet has funds
+        let userBalanceAfterWithdrawal = await wrappedCENNZ.balanceOf(wallet.address);
+        expect(userBalanceAfterWithdrawal).to.equal(userBalanceStart + withdrawalAmount);
+
+        // DEPOSIT
+        let depositAmount = 5;
+        let cennznetAddress = '0xacd6118e217e552ba801f7aa8a934ea6a300a5b394e7c3f42cd9d6dd9a457c10';
+        await erc20Peg.activateDeposits();
+
+        estimatedGas = await erc20Peg.estimateGas.deposit(
+            wrappedCENNZ.address,
+            depositAmount,
+            cennznetAddress,
+            {
+                gasLimit: 500000,
+            }
+        );
+        console.log(`deposit gas: ${estimatedGas}`);
+
+        await expect(
+            erc20Peg.deposit(
+                wrappedCENNZ.address,
+                depositAmount,
+                cennznetAddress,
+                {
+                    gasLimit: estimatedGas,
+                })
+        ).to.emit(erc20Peg, 'Deposit').withArgs(wallet.address, wrappedCENNZ.address, depositAmount, cennznetAddress);
+
+        // Check account has correct funds
+        let userBalanceAfterDeposit = await wrappedCENNZ.balanceOf(wallet.address);
+        expect(userBalanceAfterDeposit).to.equal(userBalanceAfterWithdrawal - depositAmount);
+    });
+});


### PR DESCRIPTION
Adds Wrapped CENNZ contract
Adds WCENNZ tests

Note, the TransferFrom override doesn't clear approvals for the Peg Contract before burning. This is intentional as it nearly halves the amount of gas used to submit a deposit. There are no noticeable benefits for removing approvals every time a deposit is made as this situation is exclusive to the WCENNZ TransferFrom function being called by the Peg Contract. 