### PR TITLE
Wrapped Cennz Improvement

### DIFF
--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         docker network create my-bridge-net
         docker run --pull=always --network=my-bridge-net --name ethNode -p 8545:8545 -p 30303:30303 -d ethereumoptimism/hardhat
-        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.1.0-rc1 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
+        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.1.0 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
         docker exec testnet_node_alice curl ethNode:8545
     # - name: deposit/withdraw scenarios for erc20 tokens
     #   env:

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -6,12 +6,10 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
 contract WrappedCENNZ is ERC20, ERC20Pausable, AccessControl {
-    // CENNZnet ERC20 peg address
-    address public pegAddress;
+    /** @dev The minter role is the role that is allowed to mint/burn */
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {
-        pegAddress = _pegAddress;
         // Grant the peg address the role to mint
         _setupRole(MINTER_ROLE, _pegAddress);
         // Grant the contract deployer the default admin role: it will be able
@@ -70,7 +68,7 @@ contract WrappedCENNZ is ERC20, ERC20Pausable, AccessControl {
     function unpause() public onlyRole(DEFAULT_ADMIN_ROLE) {
       _unpause();
     }
-    
+
     /** @dev Interfaces ERC20Pausable. */
     function _beforeTokenTransfer(
         address from,

--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -1,33 +1,82 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 
-contract WrappedCENNZ is ERC20 {
-    // CENNZnet erc20 peg address
+contract WrappedCENNZ is ERC20, ERC20Pausable, AccessControl {
+    // CENNZnet ERC20 peg address
     address public pegAddress;
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     constructor(address _pegAddress) ERC20("Wrapped CENNZ", "WCENNZ") {
         pegAddress = _pegAddress;
+        // Grant the peg address the role to mint
+        _setupRole(MINTER_ROLE, _pegAddress);
+        // Grant the contract deployer the default admin role: it will be able
+        // to grant and revoke any roles
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
+    /** @dev Upon token transfer, if the address is the minter role we burn the tokens.
+      * @param owner The from address.
+      * @param buyer The to address.
+      * @param numTokens The number of tokens to be tranferred.
+      * @return bool Whether the transfer was successful.
+      */
     function transferFrom(address owner, address buyer, uint256 numTokens) public override returns (bool) {
-        if (msg.sender == pegAddress) {
-            _burn(owner, numTokens);
+        if (hasRole(MINTER_ROLE, msg.sender)) {
+            burn(owner, numTokens);
             return true;
         }
         return super.transferFrom(owner, buyer, numTokens);
     }
 
+    /** @dev Upon token transfer, if the address is the minter role we mint new tokens to the purchaser.
+      * @param buyer The to address.
+      * @param numTokens The number of tokens to be tranferred.
+      * @return bool Whether the transfer was successful.
+      */
     function transfer(address buyer, uint256 numTokens) public override returns (bool) {
-        if (msg.sender == pegAddress) {
-            _mint(buyer, numTokens);
+        if (hasRole(MINTER_ROLE, msg.sender)) {
+            mint(buyer, numTokens);
             return true;
         }
         return super.transfer(buyer, numTokens);
     }
 
+    /** @dev The mint function is protected by the onlyRole modifier. */
+    function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    /** @dev The burn function is protected by the onlyRole modifier. */
+    function burn(address from, uint256 amount) public onlyRole(MINTER_ROLE) {
+        _burn(from, amount);
+    }
+
+    /** @dev The amount of decimals for Wrapped CENNZ is 4 decimals. */
     function decimals() public pure override returns (uint8) {
         return 4;
+    }
+
+    /** @dev Allow the admin to pause transfers. */
+    function pause() public onlyRole(DEFAULT_ADMIN_ROLE) {
+      _pause();
+    }
+
+    /** @dev Allow the admin to unpause transfers. */
+    function unpause() public onlyRole(DEFAULT_ADMIN_ROLE) {
+      _unpause();
+    }
+    
+    /** @dev Interfaces ERC20Pausable. */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual override(ERC20, ERC20Pausable) {
+        super._beforeTokenTransfer(from, to, amount);
     }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,7 +4,7 @@ require("dotenv").config();
 
 module.exports = {
   solidity: {
-    version: "0.8.4",
+    version: "0.8.13",
       settings: {
       optimizer: {
         enabled: true,

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -140,7 +140,7 @@ describe('Erc20Peg', () => {
     });
 
     it('approve and transfer wrapped CENNZ', async () => {
-        let withdrawalAmount = 100;
+        let withdrawalAmount = 10;
         let userBalanceStart = await wrappedCENNZ.balanceOf(wallet.address);
         await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
 

--- a/test/wcennz.test.ts
+++ b/test/wcennz.test.ts
@@ -1,48 +1,46 @@
 import { expect, use } from 'chai';
 import { Contract, ethers } from 'ethers';
 import { deployContract, MockProvider, solidity } from 'ethereum-waffle';
-import CENNZnetBridge from '../artifacts/contracts/CENNZnetBridge.sol/CENNZnetBridge.json';
 import ERC20Peg from '../artifacts/contracts/ERC20Peg.sol/ERC20Peg.json';
 import MockBridge from '../artifacts/contracts/MockBridge.sol/MockBridge.json';
 import WrappedCENNZ from '../artifacts/contracts/WrappedCENNZ.sol/WrappedCENNZ.json';
+import { keccak256 } from 'ethers/lib/utils';
 
 use(solidity);
 
 describe('Erc20Peg', () => {
     const [wallet, walletTo] = new MockProvider().getWallets();
-    let bridge: Contract;
     let erc20Peg: Contract;
     let mockBridge: Contract;
     let wrappedCENNZ: Contract;
+    // use with mockBridge to withdraw tokens
+    let FAKE_WITHDRAW_PROOF = {
+        eventId: 1,
+        validatorSetId: 0,
+        validators: [],
+        v: [],
+        r: [],
+        s: [],
+    };
 
     beforeEach(async () => {
-        bridge = await deployContract(wallet, CENNZnetBridge, []);
         mockBridge = await deployContract(wallet, MockBridge, []);
         erc20Peg = await deployContract(wallet, ERC20Peg, [mockBridge.address]);
+        await erc20Peg.activateWithdrawals();
         wrappedCENNZ = await deployContract(wallet, WrappedCENNZ, [erc20Peg.address]);
     });
 
     it('withdraw wrapped CENNZ then deposit', async () => {
         let withdrawalAmount = 10;
         let userBalanceStart = await wrappedCENNZ.balanceOf(wallet.address);
-        await erc20Peg.activateWithdrawals();
         await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
-
-        let fakeWithdrawProof = {
-            eventId: 1,
-            validatorSetId: 0,
-            validators: [],
-            v: [],
-            r: [],
-            s: [],
-        };
 
         // TEST
         let estimatedGas = await erc20Peg.estimateGas.withdraw(
             wrappedCENNZ.address,
             withdrawalAmount,
             wallet.address,
-            fakeWithdrawProof,
+            FAKE_WITHDRAW_PROOF,
             {
                 gasLimit: 500000,
             }
@@ -54,7 +52,7 @@ describe('Erc20Peg', () => {
                 wrappedCENNZ.address,
                 withdrawalAmount,
                 wallet.address,
-                fakeWithdrawProof,
+                FAKE_WITHDRAW_PROOF,
                 {
                     gasLimit: estimatedGas,
                 })
@@ -97,24 +95,14 @@ describe('Erc20Peg', () => {
     it('transfer wrapped CENNZ', async () => {
         let withdrawalAmount = 10;
         let userBalanceStart = await wrappedCENNZ.balanceOf(wallet.address);
-        await erc20Peg.activateWithdrawals();
         await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
-
-        let fakeWithdrawProof = {
-            eventId: 1,
-            validatorSetId: 0,
-            validators: [],
-            v: [],
-            r: [],
-            s: [],
-        };
 
         // TEST
         let estimatedGas = await erc20Peg.estimateGas.withdraw(
             wrappedCENNZ.address,
             withdrawalAmount,
             wallet.address,
-            fakeWithdrawProof,
+            FAKE_WITHDRAW_PROOF,
             {
                 gasLimit: 500000,
             }
@@ -125,7 +113,7 @@ describe('Erc20Peg', () => {
                 wrappedCENNZ.address,
                 withdrawalAmount,
                 wallet.address,
-                fakeWithdrawProof,
+                FAKE_WITHDRAW_PROOF,
                 {
                     gasLimit: estimatedGas,
                 })
@@ -152,40 +140,18 @@ describe('Erc20Peg', () => {
     });
 
     it('approve and transfer wrapped CENNZ', async () => {
-        let withdrawalAmount = 10;
+        let withdrawalAmount = 100;
         let userBalanceStart = await wrappedCENNZ.balanceOf(wallet.address);
-        await erc20Peg.activateWithdrawals();
         await wrappedCENNZ.approve(erc20Peg.address, withdrawalAmount);
 
-        let fakeWithdrawProof = {
-            eventId: 1,
-            validatorSetId: 0,
-            validators: [],
-            v: [],
-            r: [],
-            s: [],
-        };
-
         // TEST
-        let estimatedGas = await erc20Peg.estimateGas.withdraw(
-            wrappedCENNZ.address,
-            withdrawalAmount,
-            wallet.address,
-            fakeWithdrawProof,
-            {
-                gasLimit: 500000,
-            }
-        );
-
         await expect(
             erc20Peg.withdraw(
                 wrappedCENNZ.address,
                 withdrawalAmount,
                 wallet.address,
-                fakeWithdrawProof,
-                {
-                    gasLimit: estimatedGas,
-                })
+                FAKE_WITHDRAW_PROOF,
+            )
         ).to.emit(erc20Peg, 'Withdraw').withArgs(wallet.address, wrappedCENNZ.address, withdrawalAmount);
 
         // Check wallet has funds
@@ -205,25 +171,64 @@ describe('Erc20Peg', () => {
         );
         const approvedAccount = wrappedCENNZ.connect(walletTo);
 
-        estimatedGas = await approvedAccount.estimateGas.transferFrom(
-            wallet.address,
-            recipient,
-            transferAmount,
-            {
-                gasLimit: 500000,
-            }
-        );
         await approvedAccount.transferFrom(
             wallet.address,
             recipient,
             transferAmount,
-            {
-                gasLimit: estimatedGas
-            },
         );
 
         // Check funds have transferred correctly
         expect(await wrappedCENNZ.balanceOf(recipient)).to.equal(recipientBalanceBeforeTransfer + transferAmount);
         expect(await wrappedCENNZ.balanceOf(wallet.address)).to.equal(userBalanceAfterWithdrawal - transferAmount);
+    });
+
+    it('only minter role can mint & burn', async () => {
+        let minterRole = keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE'));
+        await expect(
+            wrappedCENNZ.mint(wallet.address, 1000)
+        ).to.be.revertedWith(`AccessControl: account 0x17ec8597ff92c3f44523bdc65bf0f1be632917ff is missing role ${minterRole}`);
+
+        await expect(
+            wrappedCENNZ.mint(wallet.address, 1000)
+        ).to.be.revertedWith(`AccessControl: account 0x17ec8597ff92c3f44523bdc65bf0f1be632917ff is missing role ${minterRole}`);
+    });
+
+    it('pause & unpause', async () => {
+        // setup
+        let withdrawalAmount = 100;
+        await erc20Peg.withdraw(
+            wrappedCENNZ.address,
+            withdrawalAmount,
+            wallet.address,
+            FAKE_WITHDRAW_PROOF,
+        );
+        await erc20Peg.activateDeposits();
+
+        // pause transfer/deposit/withdraw fails
+        await wrappedCENNZ.pause();
+        await expect(
+            wrappedCENNZ.transfer(wallet.address, 2)
+        ).to.reverted.returned;
+        await expect(
+            erc20Peg.withdraw(
+            wrappedCENNZ.address,
+            5,
+            wallet.address,
+            FAKE_WITHDRAW_PROOF,
+        )).to.reverted.returned;
+        await expect(
+            erc20Peg.deposit(
+                wrappedCENNZ.address,
+                5,
+                '0x0903fdd2dea80c6e24743f8363044948447689d3e8f19a4c63046ff8f2150281',
+            )
+        ).to.reverted.returned;
+
+        // unpause transfer ok
+        await wrappedCENNZ.unpause();
+        let recipient = '0xa86e122EdbDcBA4bF24a2Abf89F5C230b37DF49d';
+        let beforeBalance = await wrappedCENNZ.balanceOf(recipient);
+        await wrappedCENNZ.transfer(recipient, 3)
+        expect(await wrappedCENNZ.balanceOf(recipient)).to.equal(beforeBalance + 3);
     });
 });


### PR DESCRIPTION
- Implemented ERC20Pausable

- Implemented AccessControl

- Contract now has 2 roles, the DEFAULT_ADMIN_ROLE which the deployer has. And the MINTER_ROLE which the peg address has. The DEFAULT_ADMIN_ROLE (the deployer) can revoke and grant roles to any given address at any time. This will act as a setter for the pegAddress.

- The minting and burning is now done based on role, rather than 1 specific address.

- The contract can now be paused and unpaused by an address with the DEFAULT_ADMIN_ROLE.