### PR TITLE
Removes WCENNZ floating pragma

### DIFF
--- a/contracts/WrappedCENNZ.sol
+++ b/contracts/WrappedCENNZ.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Pausable.sol";


### PR DESCRIPTION
Removes the floating pragma from the wrapped CENNZ contract as per the recommendation [here](https://github.com/kadenzipfel/smart-contract-attack-vectors/blob/master/vulnerabilities/floating-pragma.md)