### PR TITLE
Message TTL hot fix publisher

### DIFF
--- a/scripts/subscribeEthereumDeposit.js
+++ b/scripts/subscribeEthereumDeposit.js
@@ -212,14 +212,14 @@ async function mainPublisher(networkName, pegContractAddress, providerOverride= 
             logger.info(`HEALTH CHECK => OK`);
             logger.info(`At blocknumber: ${blockNumber}`);
     });
-
+    const messageTimeout = 60000 * 5; //5 minutes
     const peg = new ethers.Contract(pegContractAddress, pegAbi, provider);
     logger.info(`Connecting to CENNZnet peg contract ${pegContractAddress}...`);
     const eventConfirmations = (await api.query.ethBridge.eventConfirmations()).toNumber();
     let channel;
     if (channelOverride) channel = channelOverride;
     else channel = await rabbit.createChannel();
-    await channel.assertQueue(TOPIC_CENNZnet_CONFIRM);
+    await channel.assertQueue(TOPIC_CENNZnet_CONFIRM, {durable: true, messageTtl: messageTimeout});
     // On eth side deposit push pub sub queue with the data, if bridge is paused, update tx status as bridge paused
     peg.on("Deposit", async (sender, tokenAddress, amount, cennznetAddress, eventInfo) => {
         logger.info(`Got the event...${JSON.stringify(eventInfo)}`);

--- a/test/relayer/subscribeEthereumDeposit.test.ts
+++ b/test/relayer/subscribeEthereumDeposit.test.ts
@@ -43,12 +43,13 @@ describe('subscribeEthereumDeposit', () => {
     await BridgeClaim.deleteMany({});
     await ClaimEvents.deleteMany({});
     rabbit = await amqp.connect(process.env.RABBIT_URL);
+    const messageTimeout = 60000 * 5; //5 minutes
     sendClaimChannel = await rabbit.createChannel();
     verifyClaimChannel = await rabbit.createChannel();
     sendClaimChannel.deleteQueue(TOPIC_CENNZnet_CONFIRM);
     verifyClaimChannel.deleteQueue(TOPIC_VERIFY_CONFIRM);
-    await sendClaimChannel.assertQueue(TOPIC_CENNZnet_CONFIRM);
-    await verifyClaimChannel.assertQueue(TOPIC_VERIFY_CONFIRM);
+    await sendClaimChannel.assertQueue(TOPIC_CENNZnet_CONFIRM, {durable: true, messageTtl: messageTimeout});
+    await verifyClaimChannel.assertQueue(TOPIC_VERIFY_CONFIRM, {durable: true, messageTtl: messageTimeout});
   });
 
   afterEach(async () => {


### PR DESCRIPTION
## Description

Fix for mismatch between message TTL queue and published message

#### Fixes

- fixes this runtime error `claim-relayer-sub Error: Channel closed by server: 406 (PRECONDITION-FAILED) with message "PRECONDITION_FAILED - inequivalent arg 'x-message-ttl' for queue 'STATE_CENNZ_CONFIRM_rata'` 