### PR TITLE
Update the relayer to work with new image + old image

### DIFF
--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         docker network create my-bridge-net
         docker run --pull=always --network=my-bridge-net --name ethNode -p 8545:8545 -p 30303:30303 -d ethereumoptimism/hardhat
-        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.1.0 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
+        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:latest --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
         docker exec testnet_node_alice curl ethNode:8545
     # - name: deposit/withdraw scenarios for erc20 tokens
     #   env:

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         docker network create my-bridge-net
         docker run --pull=always --network=my-bridge-net --name ethNode -p 8545:8545 -p 30303:30303 -d ethereumoptimism/hardhat
-        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:latest --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
+        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.2.0-rc4 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
         docker exec testnet_node_alice curl ethNode:8545
     # - name: deposit/withdraw scenarios for erc20 tokens
     #   env:

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         docker network create my-bridge-net
         docker run --pull=always --network=my-bridge-net --name ethNode -p 8545:8545 -p 30303:30303 -d ethereumoptimism/hardhat
-        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.2.0-rc4 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
+        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:latest --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
         docker exec testnet_node_alice curl ethNode:8545
     # - name: deposit/withdraw scenarios for erc20 tokens
     #   env:

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         docker network create my-bridge-net
         docker run --pull=always --network=my-bridge-net --name ethNode -p 8545:8545 -p 30303:30303 -d ethereumoptimism/hardhat
-        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:latest --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
+        docker run --pull=always --network=my-bridge-net --name testnet_node_alice -p 9944:9944 -d cennznet/cennznet:2.2.0-rc3 --dev --tmp --unsafe-ws-external --unsafe-rpc-external --eth-http=http://ethNode:8545 --no-mdns
         docker exec testnet_node_alice curl ethNode:8545
     # - name: deposit/withdraw scenarios for erc20 tokens
     #   env:

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -1,5 +1,5 @@
 const { Api } = require('@cennznet/api');
-const { Keyring } = require('@polkadot/keyring');
+const { encodeAddress, Keyring } = require('@polkadot/keyring');
 const { ethers } = require("hardhat");
 
 async function main() {
@@ -96,8 +96,9 @@ async function main() {
             if (status.isInBlock) {
                 for (const {event: {method, section, data}} of events) {
                     console.log('\t', `: ${section}.${method}`, data.toString());
-                    const [, claimer] = data;
-                    if (section === 'erc20Peg' && method == 'Erc20Claim' && claimer && claimer.toString() === alice.address) {
+                    const [, address] = data;
+                    if (section === 'erc20Peg' && method == 'Erc20Claim' && address &&
+                        (address.toString() === alice.address || address.toString() === encodeAddress(claim.beneficiary))) {
                         eventClaimId = data[0];
                         console.log('*******************************************');
                         console.log('Deposit claim on CENNZnet side started for claim Id', eventClaimId.toString());

--- a/scripts/ethEndToEndTest.js
+++ b/scripts/ethEndToEndTest.js
@@ -1,6 +1,6 @@
 
 const { Api } = require('@cennznet/api');
-const { Keyring } = require('@polkadot/keyring');
+const { encodeAddress, Keyring } = require('@polkadot/keyring');
 const { ethers } = require("hardhat");
 
 async function main() {
@@ -99,8 +99,9 @@ async function main() {
             if (status.isInBlock) {
                 for (const {event: {method, section, data}} of events) {
                     console.log('\t', `: ${section}.${method}`, data.toString());
-                    const [, claimer] = data;
-                    if (section === 'erc20Peg' && method == 'Erc20Claim' && claimer && claimer.toString() === alice.address) {
+                    const [, address] = data;
+                    if (section === 'erc20Peg' && method == 'Erc20Claim' && address &&
+                        (address.toString() === alice.address || address.toString() === encodeAddress(claim.beneficiary))) {
                         eventClaimId = data[0];
                         console.log('*******************************************');
                         console.log('Deposit claim on CENNZnet side started for claim Id', eventClaimId.toString());

--- a/scripts/subscribeEthereumDeposit.js
+++ b/scripts/subscribeEthereumDeposit.js
@@ -1,7 +1,7 @@
 
 const { Api } = require('@cennznet/api');
 require("dotenv").config();
-const { Keyring } = require('@polkadot/keyring');
+const { encodeAddress, Keyring } = require('@polkadot/keyring');
 const logger = require('./logger');
 const mongoose = require('mongoose');
 const { BridgeClaim  } = require('../src/mongo/models');
@@ -58,8 +58,9 @@ async function sendClaim(claim, transactionHash, api, signer, nonce) {
             if (status.isInBlock) {
                 for (const {event: {method, section, data}} of events) {
                     console.log('\t', `: ${section}.${method}`, data.toString());
-                    const [, claimer] = data;
-                    if (section === 'erc20Peg' && method == 'Erc20Claim' && claimer && claimer.toString() === signer.address) {
+                    const [, address] = data;
+                    if (section === 'erc20Peg' && method == 'Erc20Claim' && address &&
+                        (address.toString() === signer.address || address.toString() === encodeAddress(claim.beneficiary))) {
                         const eventClaimId = data[0];
                         console.log('*******************************************');
                         console.log('Deposit claim on CENNZnet side started for claim Id', eventClaimId.toString());


### PR DESCRIPTION
## Description

Currently azalea's is at commit hash - 4ec83ee, branch azalea is from this commit hash and this PR will let the claim relayer work with the new runtime update on azalea as well as old runtime.. The event param data has changed in the new runtime

## Details

With new cennznet image, deposition on erc20Peg deposit claim, emits event with beneficiary, this PR fixes the flow in relayer and tests


#### Changes

.github/workflows/pr-any.yml
scripts/e2e.js
scripts/ethEndToEndTest.js
scripts/subscribeEthereumDeposit.js

