### PR TITLE
update validator relayer

### DIFF
--- a/scripts/subscribeEventProof.js
+++ b/scripts/subscribeEventProof.js
@@ -88,8 +88,9 @@ async function getEventPoofAndSubmit(api, eventId, bridge, txExecutor, newValida
             logger.info('Gas price nw;:', gasPrice.toString());
 
             const gasEstimated = await bridge.estimateGas.setValidators(newValidators, newValidatorSetId, proof, {gasLimit: 5000000, gasPrice: increasedGasPrice});
-
-            logger.info(JSON.stringify(await bridge.setValidators(newValidators, newValidatorSetId, proof, {gasLimit: gasEstimated.add(BUFFER), gasPrice: increasedGasPrice})));
+            const tx = await bridge.setValidators(newValidators, newValidatorSetId, proof, {gasLimit: gasEstimated.add(BUFFER), gasPrice: increasedGasPrice});
+            await tx.wait(); // wait till tx is mined
+            logger.info(JSON.stringify(tx));
             await updateLastEventProcessed(eventId, blockHash.toString());
             const balance = await provider.getBalance(txExecutor.address);
             logger.info(`IMP Balance is: ${balance}`);
@@ -174,6 +175,7 @@ async function main (networkName, bridgeContractAddress) {
             for (let i = scanFromEvent; i <=  parseInt(lastEventProofIdFromCennznet);i++ ) {
                 console.log('At Event id:',i);
                 const eventProof = await withTimeout(api.derive.ethBridge.eventProof(i), 10000);
+
                 if (eventProof && eventProof.tag === 'sys:authority-change') {
                     const checkEventExistsOnEth = await bridge.eventIds(i.toString());
                     if (!checkEventExistsOnEth) {
@@ -203,7 +205,8 @@ async function main (networkName, bridgeContractAddress) {
             const processBlockNumber = parseInt(processedBlock);
             const finalizedBlockNumber = parseInt(finalizedBlock);
             if (processBlockNumber < finalizedBlockNumber) {
-                for (let blockNumber = processBlockNumber; blockNumber < finalizedBlock; blockNumber++) {
+                // processes block + 1 will be new block to process
+                for (let blockNumber = processBlockNumber+1; blockNumber < finalizedBlock; blockNumber++) {
                     logger.info(`At blocknumber: ${blockNumber}`);
 
                     const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
@@ -211,7 +214,7 @@ async function main (networkName, bridgeContractAddress) {
                     events.map(async ({event}) => {
                         const { section, method, data } = event;
                         if (section === 'ethBridge' && method === 'AuthoritySetChange') {
-                            const dataFetched = data.toHuman();
+                            const dataFetched = data.toJSON();
                             const eventIdFound = dataFetched[0];
                             const newValidatorSetId = parseInt(dataFetched[1]);
                             logger.info(`IMP Event found at block ${blockNumber} hash ${blockHash} event id ${eventIdFound}`);

--- a/test/relayer/ethereumEventPoller.test.ts
+++ b/test/relayer/ethereumEventPoller.test.ts
@@ -39,6 +39,7 @@ describe('ethereumEventPoller', () => {
   });
 
   beforeEach(async () => {
+    const messageTimeout = 60000 * 5; //5 minutes
     testToken = await deployContract(wallet, TestToken, [1000000], {});
     bridge = await deployContract(wallet, CENNZnetBridge, []);
     erc20Peg = await deployContract(wallet, ERC20Peg, [bridge.address]);
@@ -46,7 +47,7 @@ describe('ethereumEventPoller', () => {
     await BridgeClaim.deleteMany({});
     sendClaimChannel = await rabbit.createChannel();
     sendClaimChannel.deleteQueue(TOPIC_CENNZnet_CONFIRM);
-    await sendClaimChannel.assertQueue(TOPIC_CENNZnet_CONFIRM);
+    await sendClaimChannel.assertQueue(TOPIC_CENNZnet_CONFIRM, {durable: true, messageTtl: messageTimeout});
   });
 
   after(async () => {


### PR DESCRIPTION
## Description

> Fix validator relayer issue on rata and Nikau

## Details

> Wait till tx is mined when sending event proof to the bridge, will help while looping through the old event proof submission
> Use toJSON to get number without comma over toHuman()
> Start from processed block + 1
#### Changes

>  scripts/subscribeEventProof.js
> test/relayer/ethereumEventPoller.test.ts
